### PR TITLE
Odstranění modulu ursa

### DIFF
--- a/lib/eet.js
+++ b/lib/eet.js
@@ -76,7 +76,7 @@ function doRequest (options, items) {
           return reject(responseError)
         }
         resolve(getResponseItems(response))
-      })
+      }, {timeout: 2000})
     })
   })
 }

--- a/lib/ws-security.js
+++ b/lib/ws-security.js
@@ -47,7 +47,7 @@ class WSSecurityCert {
     this.x509Id = 'x509-' + uid.replace(/-/gm, '')
 
     this.signer = new SignedXml()
-    this.signer.signingKey = new Buffer(privatePEM)
+    this.signer.signingKey = Buffer.from(privatePEM)
     this.signer.signatureAlgorithm = SIGNATURE_ALGORITHM
     this.signer.addReference("//*[local-name(.)='Body']", TRANSFORM_ALGORITHMS, DIGEST_ALGORITHM)
     this.signer.keyInfoProvider = {}

--- a/lib/ws-security.js
+++ b/lib/ws-security.js
@@ -1,5 +1,4 @@
 'use strict'
-const ursa = require('ursa')
 const SignedXml = require('xml-crypto').SignedXml
 
 const SIGNATURE_ALGORITHM = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
@@ -44,12 +43,11 @@ function getSecurityXml (id, binaryToken) {
 class WSSecurityCert {
 
   constructor (privatePEM, publicP12PEM, uid) {
-    this.privateKey = ursa.createPrivateKey(privatePEM, '', 'utf8')
     this.publicP12PEM = removeCertHeaderAndFooter(publicP12PEM)
     this.x509Id = 'x509-' + uid.replace(/-/gm, '')
 
     this.signer = new SignedXml()
-    this.signer.signingKey = this.privateKey.toPrivatePem()
+    this.signer.signingKey = new Buffer(privatePEM)
     this.signer.signatureAlgorithm = SIGNATURE_ALGORITHM
     this.signer.addReference("//*[local-name(.)='Body']", TRANSFORM_ALGORITHMS, DIGEST_ALGORITHM)
     this.signer.keyInfoProvider = {}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "node-uuid": "^1.4.7",
     "soap": "^0.17.0",
-    "ursa": "^0.9.4",
     "xml-crypto": "^0.8.4"
   }
 }


### PR DESCRIPTION
Odstraněn modul ursa, kde jeho použití bylo zbytečné. PEM privátní klíč není chráněn heslem. Odstraněním modulu ursa zůstane knihovna bez nativních modulů a nezpůsobí problémy při použití např. v Electron.js. Dále přidán timeout na 2000ms podle zákona o evidenci tržeb.