### PR TITLE
BKP and PKP keys when error

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pem.readPkcs12(file, {p12Password: password}, (err, result) => {
   * *options.playground* (bool) - Posílat požadavky na playground? Def. false (ne).
   * *options.httpClient* - Viz [soap options](https://github.com/vpulim/node-soap#options), slouží pro testování.
   * *options.timeout* (number) - Nastavení max. timeoutu (defaultně 2000 ms)
+  * *options.offline* (bool) - Do chybové hlášky vkládat PKP a BKP
 * *items* - Položky, které se posílají do EET. Mají stejný název jako ve specifikaci EET, jen používají cammel case (tedy místo dic_popl se používá dicPopl).
 
 ## Časté chyby

--- a/lib/eet.js
+++ b/lib/eet.js
@@ -50,6 +50,7 @@ function generateBKP (pkp) {
  *
  * Volby:
  * - options.playground (boolean): povolit testovaci prostredi, def. false
+ * - options.offline (boolean): při chybě vygeneruje PKP a BKP, def. false
 
  * Polozky (items) jsou popsany u funkce getItemsForBody().
  *
@@ -66,6 +67,7 @@ function doRequest (options, items) {
     soapOptions.httpClient = options.httpClient
   }
   const timeout = options.timeout || 2000
+  const offline = options.offline || false
 
   return new Promise((resolve, reject) => {
     const body = getBodyItems(options.privateKey, date, uid, items)
@@ -82,6 +84,10 @@ function doRequest (options, items) {
         }
       }, {timeout: timeout})
     })
+  }).catch(err => {
+    if (!offline) return Promise.reject(err)
+    let {pkp, bkp} = getFooterItems(options.privateKey, items)
+    return Promise.resolve({pkp: pkp.$value, bkp: bkp.$value, err})
   })
 }
 


### PR DESCRIPTION
Nový parametr `options.offline`, který v případě `true` bude vracet v chybových hláškách PKP a BKP klíče. Vhodné pro offline použití.

Fixes #8 