### PR TITLE
Fixed cash register regex

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -45,7 +45,7 @@ function businessPremisesId (value) {
  *
  */
 function cashRegisterId (value) {
-  if (!/^[0-9a-zA-Z\.,:;/#\-_]{1,20}$/.test(value)) {
+  if (!/^[0-9a-zA-Z\.,:;/#\-_ ]{1,20}$/.test(value)) {
     throw new Error(`Value '${value}' doesn't match pattern for cash register ID.`)
   }
 }


### PR DESCRIPTION
The cash register regex was not allowing spaces, even though they are allowed by the spec (http://www.etrzby.cz/assets/cs/prilohy/EET_popis_rozhrani_v3.1.1.pdf)